### PR TITLE
Fixed the link to contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This playground doesn't include any Appwrite best practices but rather intended 
 
 All code contributions - including those of people having commit access - must go through a pull request and approved by a core developer before being merged. This is to ensure proper review of all the code.
 
-We truly ❤️ pull requests! If you wish to help, you can learn more about how you can contribute to this project in the [contribution guide]([CONTRIBUTING.md](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)).
+We truly ❤️ pull requests! If you wish to help, you can learn more about how you can contribute to this project in the [contribution guide](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md).
 
 ## Security
 


### PR DESCRIPTION
closes #10 
Earlier the link to the contribution guide was not working.
![rename](https://user-images.githubusercontent.com/47494475/94743268-b4e6cd80-0394-11eb-9bde-d8b204e6842f.png)